### PR TITLE
Fixed 'Extending the Visual Scripting Language' code sample not working

### DIFF
--- a/tutorials/src/gameplay_coding/extend_the_visual_scripting_language.md
+++ b/tutorials/src/gameplay_coding/extend_the_visual_scripting_language.md
@@ -26,12 +26,12 @@ Our goal is to create a node that computes the square of a floating-point number
 
 ```c
 GGN_BEGIN("Sample/Math/Float");
+GGN_GEN_REGISTER_FUNCTION();
 GGN_NODE_QUERY();
 static inline void sample_float_square(float a, float *res)
 {
     *res = a * a;
 }
-GGN_GEN_REGISTER_FUNCTION();
 GGN_END();
 #include "my_graph_nodes.inl"
 ```


### PR DESCRIPTION
Fixed 'Extending the Visual Scripting Language' code sample not working by moving 'GGN_GEN_REGISTER_FUNCTION' up. 
This caused 'generate-graph-nodes' to not generate 'generated__register_graph_nodes', therefore breaking the code sample.